### PR TITLE
More robust decoding / encoding?

### DIFF
--- a/Controller/Component/CsvComponent.php
+++ b/Controller/Component/CsvComponent.php
@@ -39,7 +39,7 @@ class CsvComponent extends Component {
 	 * @access protected
 	 */
 	protected function _encode($str = '') {
-		return iconv("UTF-8","WINDOWS-1257", html_entity_decode($str, ENT_COMPAT, 'utf-8'));
+		return iconv("UTF-8","UTF-8//TRANSLIT", html_entity_decode($str, ENT_COMPAT, 'utf-8'));
 	}
 
 	/**


### PR DESCRIPTION
The current implementation, as I understand it, convert the string to UTF-8 via `html_entity_decode`, then back to "WINDOWS-1257". This might work for many strings but not for all. To take an example, the `iconv()` call will fail on the string "øÂ" (and others).

So rather than converting to WINDOWS-1257, I suggest converting to "UTF-8//TRANSLIT". UTF-8 covers any existing character and "//TRANSLIT" ensures that if there is any weird character, at least the encoding doesn't fail completely like it currently does.

That being said, I realize that CSV generation is a complicated matter so it's possible I'm missing something about the current encoding. At least, for my use case, using UTF-8//TRANSLIT always work. Please let me know what you think about it.